### PR TITLE
Add 'require-trusted-types-for'

### DIFF
--- a/Sources/Koba/Directives.swift
+++ b/Sources/Koba/Directives.swift
@@ -188,6 +188,10 @@ public class CSP {
         return self
     }
 
+    public func requireTrustedTypesFor(_ values: String...) -> CSP {
+        directives.append("require-trusted-types-for \(values.joined(separator: " "))")
+    }
+
     public func reportTo(_ reportTo: ReportTo...) -> CSP {
         var reporting: [String] = []
         _ = reportTo.map { report in

--- a/Sources/Koba/Directives.swift
+++ b/Sources/Koba/Directives.swift
@@ -190,6 +190,7 @@ public class CSP {
 
     public func requireTrustedTypesFor(_ values: String...) -> CSP {
         directives.append("require-trusted-types-for \(values.joined(separator: " "))")
+        return self
     }
 
     public func reportTo(_ reportTo: ReportTo...) -> CSP {

--- a/Sources/Koba/Utils.swift
+++ b/Sources/Koba/Utils.swift
@@ -45,7 +45,7 @@ extension Koba {
         public static let strictDynamic = "'strict-dynamic'"
         public static let unsafeEval = "'unsafe-eval'"
         public static let unsafeInline = "'unsafe-inline'"
-        public static let script = "'script"
+        public static let script = "'script'"
         public static let wildcard = "*"
     }
 

--- a/Sources/Koba/Utils.swift
+++ b/Sources/Koba/Utils.swift
@@ -45,6 +45,7 @@ extension Koba {
         public static let strictDynamic = "'strict-dynamic'"
         public static let unsafeEval = "'unsafe-eval'"
         public static let unsafeInline = "'unsafe-inline'"
+        public static let script = "'script"
         public static let wildcard = "*"
     }
 


### PR DESCRIPTION
Following this specification: https://w3c.github.io/webappsec-trusted-types/dist/spec/#require-trusted-types-for-csp-directive
and the suggestion of the Google CSP evaluator: https://csp-evaluator.withgoogle.com/
This PR adds the new 'require-trusted-types-for' and the Source named 'script'.